### PR TITLE
Improve Chart.js benchmark by skipping label rotation

### DIFF
--- a/bench/Chart.js.html
+++ b/bench/Chart.js.html
@@ -103,7 +103,9 @@
 								distribution: 'series',
 								ticks: {
 									source: 'auto',
-									autoSkip: true
+									maxRotation: 0,
+									autoSkip: true,
+									autoSkipPadding: 75
 								}
 							}],
 							yAxes: [{


### PR DESCRIPTION
I'm working on the Chart.js documentation to add some performance tips and have [suggested they add this tip](https://github.com/chartjs/Chart.js/pull/6585). I don't think Chart.js will ever be as fast as uPlot, but it should be at least as fast as Highcharts, etc.

Setting `maxRotation: 0` allows Chart.js to skip calculating how much to rotate the labels to fit them on the chart and just makes them all horizontal.

`autoSkipPadding` mostly just makes it look a little nicer by putting some spacing between labels