### PR TITLE
Upgrade to Chart.js 2.9.0

### DIFF
--- a/bench/Chart.js.html
+++ b/bench/Chart.js.html
@@ -11,7 +11,7 @@
 		<h2 id="wait">Loading lib....</h2>
 
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.min.js"></script>
-		<script src="https://www.chartjs.org/dist/2.8.0/Chart.min.js"></script>
+		<script src="https://www.chartjs.org/dist/2.9.0/Chart.min.js"></script>
 		<script src="https://www.chartjs.org/samples/latest/utils.js"></script>
 
 		<canvas id="chart1"></canvas>
@@ -105,7 +105,8 @@
 									source: 'auto',
 									maxRotation: 0,
 									autoSkip: true,
-									autoSkipPadding: 75
+									autoSkipPadding: 75,
+									sampleSize: 1
 								}
 							}],
 							yAxes: [{


### PR DESCRIPTION
The results before and after are really variable, but this looks like it's around 25-33% faster.

The two largest issues that Chart.js still has in terms of speed compared to uPlot are accepting varied input (parsing, linear and timeseries support in time scale, etc.) and animation support (which is still costly even when off due to the way the code is structured).