### PR TITLE
Chart.js - use linear distribution of time

### DIFF
--- a/bench/Chart.js.html
+++ b/bench/Chart.js.html
@@ -110,7 +110,6 @@
 						scales: {
 							xAxes: [{
 								type: 'time',
-								distribution: 'series',
 								ticks: {
 									source: 'auto',
 									maxRotation: 0,


### PR DESCRIPTION
Use default `'linear'` distribution of time. Its faster.
`'series'` mode plots each point with equal distance between, `'linear'` uses the given time to determine distance.