### PR TITLE
Bugfix for #117

### DIFF
--- a/src/Line.js
+++ b/src/Line.js
@@ -1043,12 +1043,15 @@ export function Line(opts, data, then) {
 
 	function toggleDOM(i, onOff) {
 		let s = series[i];
-		let label = legendRows[i][0].parentNode;
+		let label;
+		if (legendOpts.show) {
+			label = legendRows[i][0].parentNode;
+		}
 
-		if (s.show)
-			remClass(label, "off");
-		else {
-			addClass(label, "off");
+		if (s.show) {
+			if (label) remClass(label, "off");
+		} else {
+			if (label) addClass(label, "off");
 			showPoints && trans(cursorPts[i], 0, -10)
 		}
 	}


### PR DESCRIPTION
Unable to call setSeries when legend.show is false

This checks if the legend is visible and only attempts to update if it can be found.