### PR TITLE
Chart.js no longer needs CSS

### DIFF
--- a/bench/Chart.js-next.html
+++ b/bench/Chart.js-next.html
@@ -17,7 +17,6 @@
 	<body>
 		<h2 id="wait">Loading lib....</h2>
 
-		<link rel="stylesheet" src="https://www.chartjs.org/dist/master/Chart.min.css">
 		<script src="https://cdn.jsdelivr.net/npm/luxon@1.15.0"></script>
 		<script src="https://www.chartjs.org/dist/master/Chart.min.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@0.2.0"></script>
@@ -28,8 +27,6 @@
 		</div>
 
 		<script>
-			Chart.platform.disableCSSInjection = true;
-
 			function round2(val) {
 				return Math.round(val * 100) / 100;
 			}


### PR DESCRIPTION
CSS is no longer used to detect chart resizes since https://github.com/chartjs/Chart.js/pull/7104 so the CSS file no longer exists