### PR TITLE
Upgrade Chart.js to 3.0.0-alpha

### DIFF
--- a/bench/Chart.js-next.html
+++ b/bench/Chart.js-next.html
@@ -17,10 +17,10 @@
 	<body>
 		<h2 id="wait">Loading lib....</h2>
 
-		<script src="https://cdn.jsdelivr.net/npm/luxon@1.15.0"></script>
-		<script src="https://www.chartjs.org/dist/master/Chart.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/luxon@1.22.0"></script>
+		<script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-alpha"></script>
 		<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@0.2.0"></script>
-		<script src="https://www.chartjs.org/samples/latest/utils.js"></script>
+		<script src="https://www.chartjs.org/samples/next/utils.js"></script>
 
 		<div class="chart-container">
 			<canvas id="chart1"></canvas>


### PR DESCRIPTION
This should make it so that the benchmark doesn't randomly break if there are changes on `master`