### PR TITLE
update demos/tooltips.html to work with custom scales

### DIFF
--- a/demos/tooltips.html
+++ b/demos/tooltips.html
@@ -100,7 +100,7 @@
 							tt.textContent = "(" + xVal + ", " + yVal + ")";
 
 							tt.style.left = Math.round(u.valToPos(xVal, 'x')) + "px";
-							tt.style.top = Math.round(u.valToPos(yVal, 'y')) + "px";
+							tt.style.top = Math.round(u.valToPos(yVal, s.scale)) + "px";
 						}
 					});
 				}


### PR DESCRIPTION
tooltips.html assumed all series used 'y' as scale, this commit changes that to use series specific scale which should ease integrating tooltips in custom charts