### PR TITLE
Fix type compilation

### DIFF
--- a/dist/uPlot.esm.d.ts
+++ b/dist/uPlot.esm.d.ts
@@ -276,7 +276,7 @@ declare namespace uPlot {
 		max?: number,
 	}
 
-	export type SpanGap = [number, number]
+	export type DataGap = [number, number]
 
 	export interface Series {
 		/** series on/off. when off, it will not affect its scale */
@@ -289,7 +289,7 @@ declare namespace uPlot {
 		scale?: string;
 
 		/** when true, null data values will not cause line breaks. when fn, should filter and return gaps to span */
-		spanGaps?: boolean | ((self: uPlot, foundGaps: Array<SpanGap>, seriesIdx: number) => Array<SpanGap>);
+		spanGaps?: boolean | ((self: uPlot, foundGaps: Array<DataGap>, seriesIdx: number) => Array<DataGap>);
 
 		/** legend label */
 		label?: string;

--- a/dist/uPlot.esm.d.ts
+++ b/dist/uPlot.esm.d.ts
@@ -276,6 +276,8 @@ declare namespace uPlot {
 		max?: number,
 	}
 
+	export type SpanGap = [number, number]
+
 	export interface Series {
 		/** series on/off. when off, it will not affect its scale */
 		show?: boolean;
@@ -287,7 +289,7 @@ declare namespace uPlot {
 		scale?: string;
 
 		/** when true, null data values will not cause line breaks. when fn, should filter and return gaps to span */
-		spanGaps?: boolean | ((self: uPlot, foundGaps: Array, seriesIdx: number) => Array);
+		spanGaps?: boolean | ((self: uPlot, foundGaps: Array<SpanGap>, seriesIdx: number) => Array<SpanGap>);
 
 		/** legend label */
 		label?: string;


### PR DESCRIPTION
Apparently, my previous PR #197 was not enough, after rebase to master more type compilation errors have surfaced:
![image](https://user-images.githubusercontent.com/2667662/81329693-94e20500-90a7-11ea-9896-f692a736f386.png)
What was done:
1. Added SpanGap type, inferred from "uPlot.js".
2. Used the new type to fix TS error from the screenshot above.