### PR TITLE
fire #hideSelect hook when resetting selection due on #mouseDown

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -1738,11 +1738,12 @@ export default function uPlot(opts, data, then) {
 		}
 	}
 
-	function hideSelect() {
+	function hideSelect(_fire) {
 		setSelect({
 			width:	!drag.x ? plotWidCss : 0,
 			height:	!drag.y ? plotHgtCss : 0,
 		}, false);
+		_fire !== false && fire("hideSelect");
 	}
 
 	function mouseDown(e, src, _x, _y, _w, _h, _i) {
@@ -1752,7 +1753,7 @@ export default function uPlot(opts, data, then) {
 			cacheMouse(e, src, _x, _y, _w, _h, _i, true, true);
 
 			if (select.show && (drag.x || drag.y))
-				hideSelect();
+				hideSelect(true);
 
 			if (e != null) {
 				on(mouseup, doc, mouseUp);


### PR DESCRIPTION
This adds a new hook ("hideSelect") which is optionally fired when #hideSelect is. 

This enables plugins to hook the "hideSelect" event to determine when the selection has been reset during a #mouseDown call. This is important since a #setSelect hook may not be fired during #mouseUp call, leaving plugins unaware that the selection has been effectively reset.

The implementation goal for this feature is a slightly more advanced form of the [zoom-ranger.html demo](https://github.com/leeoniya/uPlot/blob/master/demos/zoom-ranger.html) which resets the zoomed plot when the ranger plot has its selection reset due to a single mouse click.

The 2nd possible #hideSelect call in `uPlot.js` does not fire the hook since it will fire at least one #setScale hook.