### PR TITLE
Update zoom-fetch demo to accept ondblclick

### DIFF
--- a/demos/zoom-fetch.html
+++ b/demos/zoom-fetch.html
@@ -34,7 +34,7 @@
 				hooks: {
 					init: [
 						u => {
-							u.ctx.canvas.ondblclick = e => {
+							u.ctx.canvas.nextElementSibling.ondblclick = e => {
 								console.log("Fetching data for full range");
 
 								u.setData(data);


### PR DESCRIPTION
canvas.ondblclick event doesn't fire when clicking on the plot, updated to use the div.over element accessible by u.ctx.canvas.nextElementSibling #250 