### PR TITLE
Adds check for legendRows.length

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -1495,7 +1495,7 @@ export default function uPlot(opts, data, then) {
 	function _alpha(i, value) {
 		series[i].alpha = value;
 
-		if (FEAT_LEGEND && legendRows)
+		if (FEAT_LEGEND && showLegend)
 			legendRows[i][0].parentNode.style.opacity = value;
 	}
 


### PR DESCRIPTION
If `legend.show` option is set to false, then `legendRows` is an empty array
and the call to `legendRows[i][0]` on line #1499 will cause an error,
since `legendRows[i]` is undefined.