### PR TITLE
axis.textAlign

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -478,6 +478,9 @@ declare namespace uPlot {
 		/** values rotation in degrees off horizontal (only bottom axes w/ side: 2) */
 		rotate?: number | ((self: uPlot, values: Array<string|number>, axisIdx: number, foundSpace: number) => number);
 
+		/** text alignment of axis values - 1: left, 2: right */
+		align?: 1 | 2;
+
 		/** gridlines to draw from this axis' splits */
 		grid?: {
 			/** grid on/off */

--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -1295,7 +1295,9 @@ export default function uPlot(opts, data, then) {
 
 			ctx.font         = axis.font[0];
 			ctx.fillStyle    = axis.stroke || hexBlack;									// rgba?
-			ctx.textAlign    = angle > 0 ? LEFT :
+			ctx.textAlign    = axis.align == 1 ? LEFT :
+			                   axis.align == 2 ? RIGHT :
+			                   angle > 0 ? LEFT :
 			                   angle < 0 ? RIGHT :
 			                   ori == 0 ? "center" : side == 3 ? RIGHT : LEFT;
 			ctx.textBaseline = angle ||


### PR DESCRIPTION
This is my shot at adding the textAlign prop for axes. Here's the visual with negative gap values and `textAlign: 1 // left` on the y axis (tested on the `1.2.2` tag branch):

![ss](https://user-images.githubusercontent.com/62244135/97399895-dde37b00-18cc-11eb-9aa8-55066761cb06.png)

Closes #345 