### PR TITLE
fix parsing of fonts with numeric weight

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -209,7 +209,7 @@ function findIncr(min, max, incrs, dim, minSpace) {
 
 function pxRatioFont(font) {
 	let fontSize;
-	font = font.replace(/\d+/, m => (fontSize = round(m * pxRatio)));
+	font = font.replace(/(\d+)px/, (m, p1) => (fontSize = round(p1 * pxRatio)) + 'px');
 	return [font, fontSize];
 }
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/CSS/font :

> - `font-style`, `font-variant` and `font-weight` must precede `font-size`

So, if you want to pass a font weight, you must do it like so:

```js
axes: [
    { font: '500 12px Family' }
]
```

But what ends up happening is that the first number found in the string is the one used for layout calculations:

https://github.com/leeoniya/uPlot/blob/b518705cacb2cc60704d061f128be12751163007/src/uPlot.js#L209-L215

Which results in problems like this:

![ss](https://user-images.githubusercontent.com/62244135/97662466-f3d07780-1a55-11eb-90e4-1103af11ccb7.png)

So we need to match the number followed by `px`. People can't use any unit other than `px` for the font size anyway.