### PR TITLE
[typings] Fix Plot.AlignedData rest parameter type

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -126,7 +126,7 @@ declare class uPlot {
 
 export type AlignedData = [
 	xValues: number[],
-	...yValues: (number | null)[]
+	...yValues: ((number | null)[])[]
 ];
 
 export interface DateNames {


### PR DESCRIPTION
[Here's a TS Playground link demonstrating the error](https://www.typescriptlang.org/play?#code/PTAEAsBdIBwZwFwgOYEtLgK4CMB0BjAewFtgAbAUwsIDtUBPAQ2EwAUzDJhsPtgBORtgCsAdgBsAM3GiAjAGZ+wmcOGyK8xgA4AJpPzCADKOwAmLaekj+AFn3AdqOFzYdIuHbkhwAxABlZU1EAWgD5QwAoSHoYClAAQTJUZBoKHQARRkhGUABeUABtCIBIAA8ANUYyTApEUBpMYmwKACcCgF0AGhLcXvpK6tqEUAAKBqbW0AAfeswyMgBKDoj2gG4IiKIaZ1AdLMZZYcTk1Iz9vMKI0GvC2XFDG3F+LXkbUy6rm4KtdpX1zdoOz22VMRySKTSmWyFyKN1u90ez1e726cK0fw2G2isQS4NOUMYADFUKU0jCShUqjU6uNmm0PsVerh+lShqMxo06dNZvMlu0+RiAdtILt9sTSTowSdIWKSWT8rCvncHk8Xm8PnDvr81hEgA). In this case the rest parameter type should be an array of yValues arrays.