### PR TITLE
Fixed typings for setSeries

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -71,7 +71,7 @@ declare class uPlot {
 
 	// TODO: include other series style opts which are dynamically pulled?
 	/** toggles series visibility or focus */
-	setSeries(seriesIdx: number, opts: {show?: boolean, focus?: boolean}): void;
+	setSeries(seriesIdx: number | null, opts: {show?: boolean, focus?: boolean}): void;
 
 	/** adds a series */
 	addSeries(opts: Series, seriesIdx?: number): void;
@@ -772,7 +772,7 @@ export namespace Hooks {
 		setSelect?:  (self: uPlot) => void;
 
 		/** fires after a series is toggled or focused */
-		setSeries?:  (self: uPlot, seriesIdx: number, opts: Series) => void;
+		setSeries?:  (self: uPlot, seriesIdx: number | null, opts: Series) => void;
 
 		/** fires after data is updated updated */
 		setData?:    (self: uPlot) => void;


### PR DESCRIPTION
Hi @leeoniya! 

You [said](https://github.com/leeoniya/uPlot/issues/411#issuecomment-749701974) in #411 that to defocus all lines it's should be called `setSeries(null, {focus: true})`, and I found that typing for `setSeries` not matches to that signature, so I've fixed it. 