### PR TITLE
fixed drawSeries hook typings

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -900,7 +900,7 @@ declare namespace uPlot {
 			drawAxes?:   (self: uPlot) => void;
 
 			/** fires after each series is drawn */
-			drawSeries?: (self: uPlot, seriesKey: string) => void;
+			drawSeries?: (self: uPlot, seriesIdx: number) => void;
 
 			/** fires after everything is drawn */
 			draw?:       (self: uPlot) => void;


### PR DESCRIPTION
According to [this code](https://github.com/leeoniya/uPlot/blob/master/src/uPlot.js#L1304) `seriesKey` is just series' index and it should be `number`. 