### PR TITLE
Initialize series/axis after uPlot instance is fully constructed

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -877,8 +877,6 @@ export default function uPlot(opts, data, then) {
 
 	self.delSeries = delSeries;
 
-	series.forEach(initSeries);
-
 	const sidesWithAxes = [false, false, false, false];
 
 	function initAxis(axis, i) {
@@ -943,9 +941,6 @@ export default function uPlot(opts, data, then) {
 				sidesWithAxes[i] = true;
 		}
 	}
-
-	// set axis defaults
-	axes.forEach(initAxis);
 
 	function autoPadSide(self, side, sidesWithAxes, cycleNum) {
 		let [hasTopAxis, hasRgtAxis, hasBtmAxis, hasLftAxis] = sidesWithAxes;
@@ -2695,6 +2690,10 @@ export default function uPlot(opts, data, then) {
 
 		setSelect(select, false);
 	}
+
+	series.forEach(initSeries);
+	// set axis defaults
+	axes.forEach(initAxis);
 
 	if (then) {
 		if (then instanceof HTMLElement) {


### PR DESCRIPTION
Otherwise uPlot instance will be missing several instance properties inside callbacks upon series initialization, but not upon further usage (addSeries), which is a bit confusing.