### PR TITLE
WIP: Rework timeStuffs to allow time formats to be specified

### DIFF
--- a/src/opts.js
+++ b/src/opts.js
@@ -58,23 +58,24 @@ export const wholeIncrs = oneIncrs.filter(onlyWhole);
 
 export const numIncrs = decIncrs.concat(oneIncrs);
 
-const NL = "\n";
-
-const yyyy    = "{YYYY}";
-const NLyyyy  = NL + yyyy;
-const md      = "{M}/{D}";
-const NLmd    = NL + md;
-const NLmdyy  = NLmd + "/{YY}";
-
-const aa      = "{aa}";
-const hmm     = "{h}:{mm}";
-const hmmaa   = hmm + aa;
-const NLhmmaa = NL + hmmaa;
-const ss      = ":{ss}";
+export const NL = "\n";
 
 const _ = null;
 
-function genTimeStuffs(ms) {
+export function genTimeStuffs(ms, opts) {
+	opts = opts || {};
+	const yyyy    = opts.YYYY || "{YYYY}";
+	const NLyyyy  = opts.NLyyyy || NL + yyyy;
+	const md      = opts.md || "{M}/{D}";
+	const NLmd    = opts.NLmd || NL + md;
+	const NLmdyy  = opts.NLmdyy || NLmd + "/{YY}";
+
+	const aa      = opts.aa || "{aa}";
+	const hmm     = opts.hmm || "{h}:{mm}";
+	const hmmaa   = opts.hmmaa || hmm + aa;
+	const NLhmmaa = opts.NLhmmaa || NL + hmmaa;
+	const ss      = opts.ss || ":{ss}";
+
 	let	s  = ms * 1e3,
 		m  = s  * 60,
 		h  = m  * 60,
@@ -242,9 +243,6 @@ function genTimeStuffs(ms) {
 		timeAxisSplits,
 	];
 }
-
-export const [ timeIncrsMs, _timeAxisStampsMs, timeAxisSplitsMs ] = FEAT_TIME && genTimeStuffs(1);
-export const [ timeIncrsS,  _timeAxisStampsS,  timeAxisSplitsS  ] = FEAT_TIME && genTimeStuffs(1e-3);
 
 // base 2
 const binIncrs = genIncrs(2, -53, 53, [1]);

--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -135,9 +135,6 @@ import {
 
 	clampScale,
 
-	timeIncrsMs,
-	timeIncrsS,
-
 	wholeIncrs,
 	numIncrs,
 	timeAxisVal,
@@ -152,20 +149,16 @@ import {
 	timeSeriesLabel,
 	numSeriesLabel,
 
-	timeAxisSplitsMs,
-	timeAxisSplitsS,
-
 	numAxisSplits,
 	logAxisSplits,
 	asinhAxisSplits,
 
 	timeAxisStamps,
 
-	_timeAxisStampsMs,
-	_timeAxisStampsS,
-
 	timeSeriesStamp,
 	_timeSeriesStamp,
+
+	genTimeStuffs,
 
 	legendOpts,
 } from './opts';
@@ -459,6 +452,9 @@ export default function uPlot(opts, data, then) {
 //	self.tz = opts.tz || Intl.DateTimeFormat().resolvedOptions().timeZone;
 	const _tzDate  = FEAT_TIME && (opts.tzDate || (ts => new Date(round(ts / ms))));
 	const _fmtDate = FEAT_TIME && (opts.fmtDate || fmtDate);
+
+	const [ timeIncrsMs, _timeAxisStampsMs, timeAxisSplitsMs ] = FEAT_TIME && genTimeStuffs(1, opts.timeFormats);
+	const [ timeIncrsS,  _timeAxisStampsS,  timeAxisSplitsS  ] = FEAT_TIME && genTimeStuffs(1e-3, opts.timeFormats);
 
 	const _timeAxisSplits = FEAT_TIME && (ms == 1 ? timeAxisSplitsMs(_tzDate) : timeAxisSplitsS(_tzDate));
 	const _timeAxisVals   = FEAT_TIME && timeAxisVals(_tzDate, timeAxisStamps((ms == 1 ? _timeAxisStampsMs : _timeAxisStampsS), _fmtDate));


### PR DESCRIPTION
I was wanting to be able to format dates differently from the default american style. After having a look into the code, I decided to:
- Rework *opts.js* `genTimeStuffs()` to allow formats to be passed as an opts object
- Change uPlot to generate time axes functions on initialisation.

It allows users to give the time component formats in a `timeFormat` object. For example, to use DD/MM/YYYY.
```js
                        ...
			const opts = {
				width: 1920,
				height: 600,
				title: "Super Data",
				timeFormats: {
				    md: "{D}/{M}"
				}
				series: [
					{},
					{
						stroke: "red",
					},
				]
			};

			let u = new uPlot(opts, data, document.body);
```

To use YYYY-MM-DD
```js
    ...
    timeFormats: {
        md: "{M}-{D}",
        MLmdyy: "{YYYY}-{M}-{D}"
    }
````

If not specified in `timeFormats` the original defaults will be used.

This is a bit more basic than the request in https://github.com/leeoniya/uPlot/issues/474, but it is a start for allowing different formats (I currently don't have time to dig into the Intl date format stuff atm).

One thing I was wondering about was also allow you to specify the months and days in the `timeFormat` object. In the example case of [Russian names](https://leeoniya.github.io/uPlot/demos/months-ru.html), this could mean you don't need to call `uPlot.fmtDate` and just give it the arrays in the `timeFormat` object