### PR TITLE
Fix syncOpts assign in case of series.length == 1

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -2653,7 +2653,7 @@ export default function uPlot(opts, data, then) {
 			pub: retTrue,
 			sub: retTrue,
 		},
-		scales: [xScaleKey, series[1].scale],
+		scales: [xScaleKey, series[1] ? series[1].scale : null],
 		match: [retTrue, retTrue],
 		values: [null, null],
 	}, cursor.sync);


### PR DESCRIPTION
Hi @leeoniya!

[This commit](https://github.com/leeoniya/uPlot/commit/5ce1bec45d08763014bc751347a67e224c6f9bf9) brings non-backward compatibility behavior with charts when there is no series but timeline ([see this](https://jsfiddle.net/bgptvj5f/)). 

Can you take this PR and release patch version? 

