### PR TITLE
Fix rangeNum type definition to make it callable

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -126,7 +126,7 @@ declare class uPlot {
 	static assign(targ: object, ...srcs: object[]): object;
 
 	/** re-ranges a given min/max by a multiple of the range's magnitude (used internally to expand/snap/pad numeric y scales) */
-	static rangeNum: ((min: number, max: number, mult: number, extra: boolean) => uPlot.Range.MinMax) | ((min: number, max: number, cfg: uPlot.Range.Config) => uPlot.Range.MinMax);
+	static rangeNum: (min: number, max: number, mult: number | uPlot.Range.Config, extra?: boolean) => uPlot.Range.MinMax;
 
 	/** re-ranges a given min/max outwards to nearest 10% of given min/max's magnitudes, unless fullMags = true */
 	static rangeLog(min: number, max: number, base: uPlot.Scale.LogBase, fullMags: boolean): uPlot.Range.MinMax;


### PR DESCRIPTION
Before, it was impossible to call, as no arguments can satisfy
both possible types. Error when attempting to call e.g.

  `rangeNum(0, 0, 0, false);`

would look like

> TS2345: Argument of type 'number' is not assignable to parameter of type 'number & Config'.
>    Type 'number' is not assignable to type 'Config'.