### PR TITLE
demos/sparklines: remove unused `class` option

### DIFF
--- a/demos/sparklines.html
+++ b/demos/sparklines.html
@@ -87,7 +87,6 @@
 				const opts = {
 					width,
 					height,
-					class: "spark",
 					pxAlign: false,
 					cursor: {
 						show: false


### PR DESCRIPTION
Saw `spark` class as unused since there is no such class available on the page.
Ignore this pr if that's not the case.