### PR TITLE
Update typings for Sync.Scales to receive null

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -466,7 +466,7 @@ declare namespace uPlot {
 		}
 
 		export namespace Sync {
-			export type Scales = [xScaleKey: string, yScaleKey: string | null];
+			export type Scales = [xScaleKey: string | null, yScaleKey: string | null];
 
 			export type Filter = (type: string, client: uPlot, x: number, y: number, w: number, h: number, i: number) => boolean;
 

--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -466,7 +466,7 @@ declare namespace uPlot {
 		}
 
 		export namespace Sync {
-			export type Scales = [xScaleKey: string, yScaleKey: string];
+			export type Scales = [xScaleKey: string, yScaleKey: string | null];
 
 			export type Filter = (type: string, client: uPlot, x: number, y: number, w: number, h: number, i: number) => boolean;
 


### PR DESCRIPTION
Line 493 states that it is valid to pass scales like this [key, null] but the typing is not in sync with that.