### PR TITLE
add a null-check of `xKeySrc` in `cacheMosue`

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -2697,7 +2697,7 @@ export default function uPlot(opts, data, then) {
 			let [xKeySrc, yKeySrc] = syncOptsSrc.scales;
 			let [matchXKeys, matchYKeys] = syncOpts.match;
 
-			let rotSrc = xKeySrc != null && src.scales[xKeySrc].ori == 1;
+			let rotSrc = src.scales[src.axes[0].scale].ori == 1;
 
 			let xDim = scaleX.ori == 0 ? plotWidCss : plotHgtCss,
 				yDim = scaleX.ori == 1 ? plotWidCss : plotHgtCss,

--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -2697,7 +2697,7 @@ export default function uPlot(opts, data, then) {
 			let [xKeySrc, yKeySrc] = syncOptsSrc.scales;
 			let [matchXKeys, matchYKeys] = syncOpts.match;
 
-			let rotSrc = src.scales[xKeySrc].ori == 1;
+			let rotSrc = xKeySrc != null && src.scales[xKeySrc].ori == 1;
 
 			let xDim = scaleX.ori == 0 ? plotWidCss : plotHgtCss,
 				yDim = scaleX.ori == 1 ? plotWidCss : plotHgtCss,


### PR DESCRIPTION
Since a `TypeError`(reading `ori` of `undefined`) will be thrown causing blocking in browser when `config.cursor.sync.scales` was given a `[null, any]`;

Added a null checking before using it as a key