### PR TITLE
types: remove empty statement

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -949,7 +949,7 @@ declare namespace uPlot {
 			cap?: Series.Cap;
 		}
 
-		export interface Border extends OrthoLines {};
+		export interface Border extends OrthoLines {}
 
 		interface FilterableOrthoLines extends OrthoLines {
 			/** can filter which splits render lines. e.g splits.map(v => v % 2 == 0 ? v : null) */


### PR DESCRIPTION
This was causing the TypeScript error, "Statements are not allowed in ambient contexts":

```
node_modules/uplot/dist/uPlot.d.ts:952:48 - error TS1036: Statements are not allowed in ambient contexts.

952   export interface Border extends OrthoLines {};
```