### PR TITLE
Initialize scales with range check

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -524,6 +524,9 @@ export default function uPlot(opts, data, then) {
 		if (sc.min != null || sc.max != null) {
 			pendScales[k] = {min: sc.min, max: sc.max};
 			sc.min = sc.max = null;
+		} else if (sc.range !== null) {
+			const r = sc.range();
+			pendScales[k] = {min: r[0], max: r[1]};
 		}
 	}
 


### PR DESCRIPTION
On initialization the scales are always initialized to the data range even when a range function exists.