### PR TITLE
Fix null error in syncLegend-method

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -2394,8 +2394,10 @@ export default function uPlot(opts, data, then) {
 
 				let j = 0;
 
-				for (let k in vals)
-					legendCells[i][j++].firstChild.nodeValue = vals[k];
+				for (let k in vals) {
+          if (legendCells[i][j].firstChild?.nodeValue)
+            legendCells[i][j++].firstChild.nodeValue = vals[k];
+        }
 			}
 		}
 	}


### PR DESCRIPTION
This pull request fixes a null error in the syncLegend function. This error would occur when syncLegend was called before the legends were fully loaded/created.
