### PR TITLE
Update README.md exponential -> linear

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ If you truly need calendar-aware ms level precision, simply provide the timestam
 
 This format has implications that can make uPlot an awkward choice for multi-series datasets which cannot be easily aligned along their x-values.
 If one series is data-dense and the other is sparse, then the latter will need to be filled in with mostly `null` y-values.
-If each series has data at arbitrary x-values, then the x-values array must be augmented with all x-values, and all y-values arrays must be augmented with `null`s, potentially leading to exponential growth in dataset size, and a structure consisting of mostly `null`s.
+If each series has data at arbitrary x-values, then the x-values array must be augmented with all x-values, and all y-values arrays must be augmented with `null`s, potentially leading to quadratic growth in dataset size, and a structure consisting of mostly `null`s.
 
 This does not mean that all series must have identical x-values - just that they are alignable.
 For instance, it is possible to plot [series that express different time periods](https://leeoniya.github.io/uPlot/demos/time-periods.html), because the data is equally spaced.


### PR DESCRIPTION
let's say you have 10 datasets with 100k entries each. 

this is 1.1M input data points spread out across 11 arrays holding 100k entries each (1 for x, 10 for y's)

if the situation changes from sharing x values to all disjoint x-values, there will be 1M unique x values, and y arrays will be padded with 9x as many nulls as there are actual data. At all times x and y arrays must have the same length.

This results in 11M array values in the data in order to represent this. This is just a linear proportion to the number of independent x-values here not a quadratic or exponential increase. 

If we cared about making the representation more efficient here for memory usage, it should not be hard to add a separate convention to put multiple datasets into one graph, that way if you could group the x and y values that are shared together.

In this example, then there would be 10 datasets each with x and y values, making for 20 arrays of 100k elements = 2M scalars. In this case none of the data is redundant, so actually the example above only wastes 11M - 2M = 9M values (all of them inside the Y arrays, which isn't even all that bad.  