### PR TITLE
Default to crosshair cursor in plot area

### DIFF
--- a/src/uPlot.css
+++ b/src/uPlot.css
@@ -27,6 +27,10 @@
 	position: absolute;
 }
 
+.u-over {
+	cursor: crosshair;
+}
+
 .u-under {
 	overflow: hidden;
 }


### PR DESCRIPTION
I think using a crosshair cursor style over the default pointer allows the user to better understand what data point they're hovering on. Makes it easier to connect x/y axis values visually in the plot .