### PR TITLE
Add Python package to third-party integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Additionally, an ever-expanding collection of runnable [/demos](https://leeoniya
 
 - [Jupyter widget](https://github.com/sohailsomani/uplot_jupyter_widget) (Sohail Somani)
 - [React, Vue.js and Svelte](https://github.com/skalinichev/uplot-wrappers) (Sergey Kalinichev)
+- [Python](https://github.com/stephane-caron/uplot-python) (Stéphane Caron)
 
 ---
 ### Performance


### PR DESCRIPTION
This PR proposes to add the fresh [uplot-python](https://github.com/stephane-caron/uplot-python) to the list of third-party integrations.