### PR TITLE
3x faster linear pathbuilder

### DIFF
--- a/bench/uPlot-10M.html
+++ b/bench/uPlot-10M.html
@@ -60,7 +60,7 @@
 				return data;
 			}
 
-			function makeChart(data) {
+			function makeChart(data, one = false) {
 				let series = [];
 
 				for (let i = 1; i < data.length; i++) {
@@ -80,7 +80,7 @@
 					},
 					cursor: {
 						points: {
-							one: true,
+							one,
 						},
 						focus: {
 							prox: 30
@@ -105,11 +105,12 @@
 
 		//	let data1 = prepData(10);
 		//	let data1 = prepData(5e6);
+		//	let data1 = prepData(1e7);
 			let data1 = prepData(2e6);
-			let u1 = makeChart(data1);
+			let u1 = makeChart(data1, false);
 
 			let data2 = prepData(40_000, 50, 2);
-			let u2 = makeChart(data2);
+			let u2 = makeChart(data2, true);
 
 			setTimeout(() => {
 				console.time('chart1 redraw');

--- a/src/paths/linear.js
+++ b/src/paths/linear.js
@@ -43,12 +43,6 @@ export function linear(opts) {
 			const _paths = {stroke: new Path2D(), fill: null, clip: null, band: null, gaps: null, flags: BAND_CLIP_FILL};
 			const stroke = _paths.stroke;
 
-			let minY = inf,
-				maxY = -inf,
-				inY, outY, outX, drawnAtX;
-
-			let accX = pixelForX(dataX[dir == 1 ? idx0 : idx1]);
-
 			// data edges
 			let lftIdx = nonNullIdx(dataY, idx0, idx1,  1 * dir);
 			let rgtIdx = nonNullIdx(dataY, idx0, idx1, -1 * dir);
@@ -57,52 +51,84 @@ export function linear(opts) {
 
 			let hasGap = false;
 
-			for (let i = dir == 1 ? idx0 : idx1; i >= idx0 && i <= idx1; i += dir) {
-				let x = pixelForX(dataX[i]);
-				let yVal = dataY[i];
+			// decimate when number of points >= 4x available pixels
+			const decimate = idx1 - idx0 >= xDim * 4;
 
-				if (x == accX) {
-					if (yVal != null) {
-						outY = pixelForY(yVal);
+			if (decimate) {
+				let xForPixel = pos => u.posToVal(pos, scaleX.key, true);
 
-						if (minY == inf) {
-							lineTo(stroke, x, outY);
-							inY = outY;
+				let minY = null,
+					maxY = null,
+					inY, outY, drawnAtX;
+
+				let accX = pixelForX(dataX[dir == 1 ? idx0 : idx1]);
+
+				let idx0px = pixelForX(dataX[idx0]);
+				let idx1px = pixelForX(dataX[idx1]);
+
+				// tracks limit of current x bucket to avoid having to get x pixel for every x value
+				let nextAccXVal = xForPixel(dir == 1 ? idx0px + 1 : idx1px - 1);
+
+				for (let i = dir == 1 ? idx0 : idx1; i >= idx0 && i <= idx1; i += dir) {
+					let xVal = dataX[i];
+					let reuseAccX = dir == 1 ? (xVal < nextAccXVal) : (xVal > nextAccXVal);
+					let x = reuseAccX ? accX :  pixelForX(xVal);
+
+					let yVal = dataY[i];
+
+					if (x == accX) {
+						if (yVal != null) {
+							outY = yVal;
+
+							if (minY == null) {
+								lineTo(stroke, x, pixelForY(outY));
+								inY = minY = maxY = outY;
+							} else {
+								if (outY < minY)
+									minY = outY;
+								else if (outY > maxY)
+									maxY = outY;
+							}
+						}
+						else {
+							if (yVal === null)
+								hasGap = true;
+						}
+					}
+					else {
+						if (minY != null)
+							drawAcc(stroke, accX, pixelForY(minY), pixelForY(maxY), pixelForY(inY), pixelForY(outY));
+
+						if (yVal != null) {
+							outY = yVal;
+							lineTo(stroke, x, pixelForY(outY));
+							minY = maxY = inY = outY;
+						}
+						else {
+							minY = maxY = null;
+
+							if (yVal === null)
+								hasGap = true;
 						}
 
-						minY = min(outY, minY);
-						maxY = max(outY, maxY);
-					}
-					else {
-						if (yVal === null)
-							hasGap = true;
+						accX = x;
+						nextAccXVal = xForPixel(accX + dir);
 					}
 				}
-				else {
-					if (minY != inf) {
-						drawAcc(stroke, accX, minY, maxY, inY, outY);
-						outX = drawnAtX = accX;
-					}
 
-					if (yVal != null) {
-						outY = pixelForY(yVal);
-						lineTo(stroke, x, outY);
-						minY = maxY = inY = outY;
-					}
-					else {
-						minY = inf;
-						maxY = -inf;
+				if (minY != null && minY != maxY && drawnAtX != accX)
+					drawAcc(stroke, accX, pixelForY(minY), pixelForY(maxY), pixelForY(inY), pixelForY(outY));
+			}
+			else {
+				for (let i = dir == 1 ? idx0 : idx1; i >= idx0 && i <= idx1; i += dir) {
+					let yVal = dataY[i];
 
-						if (yVal === null)
-							hasGap = true;
-					}
-
-					accX = x;
+					if (yVal === null)
+						hasGap = true;
+					else if (yVal != null)
+						lineTo(stroke, pixelForX(dataX[i]), pixelForY(yVal));
 				}
 			}
-
-			if (minY != inf && minY != maxY && drawnAtX != accX)
-				drawAcc(stroke, accX, minY, maxY, inY, outY);
 
 			let [ bandFillDir, bandClipDir ] = bandFillClipDirs(u, seriesIdx);
 
@@ -116,7 +142,7 @@ export function linear(opts) {
 				lineTo(fill, lftX, fillToY);
 			}
 
-			if (!series.spanGaps) {
+			if (!series.spanGaps) { // skip in mode: 2?
 			//	console.time('gaps');
 				let gaps = [];
 

--- a/src/paths/spline.js
+++ b/src/paths/spline.js
@@ -1,4 +1,4 @@
-import { ifNull, nonNullIdx } from '../utils';
+import { ifNull, nonNullIdxs } from '../utils';
 import { orient, clipGaps, moveToH, moveToV, lineToH, lineToV, bezierCurveToH, bezierCurveToV, clipBandLine, BAND_CLIP_FILL, bandFillClipDirs, findGaps } from './utils';
 
 export function splineInterp(interp, opts) {
@@ -6,6 +6,8 @@ export function splineInterp(interp, opts) {
 
 	return (u, seriesIdx, idx0, idx1) => {
 		return orient(u, seriesIdx, (series, dataX, dataY, scaleX, scaleY, valToPosX, valToPosY, xOff, yOff, xDim, yDim) => {
+			[idx0, idx1] = nonNullIdxs(dataY, idx0, idx1);
+
 			let pxRound = series.pxRound;
 
 			let pixelForX = val => pxRound(valToPosX(val, scaleX, xDim, xOff));
@@ -25,9 +27,6 @@ export function splineInterp(interp, opts) {
 			}
 
 			const dir = scaleX.dir * (scaleX.ori == 0 ? 1 : -1);
-
-			idx0 = nonNullIdx(dataY, idx0, idx1,  1);
-			idx1 = nonNullIdx(dataY, idx0, idx1, -1);
 
 			let firstXPos = pixelForX(dataX[dir == 1 ? idx0 : idx1]);
 			let prevXPos = firstXPos;

--- a/src/paths/stepped.js
+++ b/src/paths/stepped.js
@@ -1,4 +1,4 @@
-import { nonNullIdx, ifNull } from '../utils';
+import { ifNull, nonNullIdxs } from '../utils';
 import { orient, clipGaps, lineToH, lineToV, clipBandLine, BAND_CLIP_FILL, bandFillClipDirs, findGaps } from './utils';
 import { pxRatio } from '../dom';
 
@@ -12,6 +12,8 @@ export function stepped(opts) {
 
 	return (u, seriesIdx, idx0, idx1) => {
 		return orient(u, seriesIdx, (series, dataX, dataY, scaleX, scaleY, valToPosX, valToPosY, xOff, yOff, xDim, yDim) => {
+			[idx0, idx1] = nonNullIdxs(dataY, idx0, idx1);
+
 			let pxRound = series.pxRound;
 
 			let { left, width } = u.bbox;
@@ -25,9 +27,6 @@ export function stepped(opts) {
 			const stroke = _paths.stroke;
 
 			const dir = scaleX.dir * (scaleX.ori == 0 ? 1 : -1);
-
-			idx0 = nonNullIdx(dataY, idx0, idx1,  1);
-			idx1 = nonNullIdx(dataY, idx0, idx1, -1);
 
 			let prevYPos  = pixelForY(dataY[dir == 1 ? idx0 : idx1]);
 			let firstXPos = pixelForX(dataX[dir == 1 ? idx0 : idx1]);

--- a/src/paths/utils.js
+++ b/src/paths/utils.js
@@ -1,4 +1,4 @@
-import { round, incrRound, retArg0, nonNullIdx, min, EMPTY_ARR, ifNull } from "../utils";
+import { round, incrRound, retArg0, min, EMPTY_ARR, ifNull } from "../utils";
 
 export const BAND_CLIP_FILL   = 1 << 0;
 export const BAND_CLIP_STROKE = 1 << 1;
@@ -243,6 +243,7 @@ export function pxRoundGen(pxAlign) {
 	return pxAlign == 0 ? retArg0 : pxAlign == 1 ? round : v => incrRound(v, pxAlign);
 }
 
+/*
 // inefficient linear interpolation that does bi-directinal scans on each call
 export function costlyLerp(i, idx0, idx1, _dirX, dataY) {
 	let prevNonNull = nonNullIdx(dataY, _dirX == 1 ? idx0 : idx1, i, -_dirX);
@@ -253,6 +254,7 @@ export function costlyLerp(i, idx0, idx1, _dirX, dataY) {
 
 	return prevVal + (i - prevNonNull) / (nextNonNull - prevNonNull) * (nextVal - prevVal);
 }
+*/
 
 function rect(ori) {
 	let moveTo = ori == 0 ?

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,63 +22,62 @@ export function closestIdx(num, arr, lo, hi) {
 	return hi;
 }
 
-export function nonNullIdx(data, _i0, _i1, dir) {
-	for (let i = dir == 1 ? _i0 : _i1; i >= _i0 && i <= _i1; i += dir) {
-		if (data[i] != null)
-			return i;
-	}
+function makeIndexOf(predicate) {
+	 let indexOf = (data, _i0, _i1, dir) => {
+		for (let i = dir == 1 ? _i0 : _i1; i >= _i0 && i <= _i1; i += dir) {
+			if (predicate(data[i]))
+				return i;
+		}
 
-	return -1;
+		return -1;
+	 };
+
+	 return indexOf;
 }
 
-export function getMinMax(data, _i0, _i1, sorted) {
+const notNullish = v => v != null;
+const isPositive = v => v != null && v > 0;
+
+export const nonNullIdx = makeIndexOf(notNullish);
+export const positiveIdx = makeIndexOf(isPositive);
+
+export function getMinMax(data, _i0, _i1, sorted = 0, log = false) {
 //	console.log("getMinMax()");
 
-	let _min = inf;
-	let _max = -inf;
+	let getEdgeIdx = log ? positiveIdx : nonNullIdx;
+	let predicate = log ? isPositive : notNullish;
 
-	if (sorted == 1) {
-		_min = data[_i0];
-		_max = data[_i1];
-	}
-	else if (sorted == -1) {
-		_min = data[_i1];
-		_max = data[_i0];
-	}
-	else {
-		for (let i = _i0; i <= _i1; i++) {
-			let v = data[i];
+	// needed?
+	_i0 = getEdgeIdx(data, _i0, _i1,  1);
+	_i1 = getEdgeIdx(data, _i0, _i1, -1);
 
-			if (v != null) {
-				if (v < _min)
-					_min = v;
-				if (v > _max)
-					_max = v;
+	let _min = data[_i0];
+	let _max = data[_i0];
+
+	if (_i0 > -1) {
+		if (sorted == 1) {
+			_min = data[_i0];
+			_max = data[_i1];
+		}
+		else if (sorted == -1) {
+			_min = data[_i1];
+			_max = data[_i0];
+		}
+		else {
+			for (let i = _i0; i <= _i1; i++) {
+				let v = data[i];
+
+				if (predicate(v)) {
+					if (v < _min)
+						_min = v;
+					else if (v > _max)
+						_max = v;
+				}
 			}
 		}
 	}
 
-	return [_min, _max];
-}
-
-export function getMinMaxLog(data, _i0, _i1) {
-//	console.log("getMinMax()");
-
-	let _min = inf;
-	let _max = -inf;
-
-	for (let i = _i0; i <= _i1; i++) {
-		let v = data[i];
-
-		if (v != null && v > 0) {
-			if (v < _min)
-				_min = v;
-			if (v > _max)
-				_max = v;
-		}
-	}
-
-	return [_min, _max];
+	return [_min ?? inf, _max ?? -inf]; // todo: fix to return nulls
 }
 
 export function rangeLog(min, max, base, fullMags) {
@@ -295,6 +294,8 @@ export function fnOrSelf(v) {
 
 export const noop = () => {};
 
+// note: these identity fns may get deoptimized if reused for different arg types
+// a TS version would enforce they stay monotyped and require making variants
 export const retArg0 = _0 => _0;
 
 export const retArg1 = (_0, _1) => _1;

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,34 +22,44 @@ export function closestIdx(num, arr, lo, hi) {
 	return hi;
 }
 
-function makeIndexOf(predicate) {
-	 let indexOf = (data, _i0, _i1, dir) => {
-		for (let i = dir == 1 ? _i0 : _i1; i >= _i0 && i <= _i1; i += dir) {
-			if (predicate(data[i]))
-				return i;
+function makeIndexOfs(predicate) {
+	 let indexOfs = (data, _i0, _i1) => {
+		let i0 = -1;
+		let i1 = -1;
+
+		for (let i = _i0; i <= _i1; i++) {
+			if (predicate(data[i])) {
+				i0 = i;
+				break;
+			}
 		}
 
-		return -1;
+		for (let i = _i1; i >= _i0; i--) {
+			if (predicate(data[i])) {
+				i1 = i;
+				break;
+			}
+		}
+
+		return [i0, i1];
 	 };
 
-	 return indexOf;
+	 return indexOfs;
 }
 
 const notNullish = v => v != null;
 const isPositive = v => v != null && v > 0;
 
-export const nonNullIdx = makeIndexOf(notNullish);
-export const positiveIdx = makeIndexOf(isPositive);
+export const nonNullIdxs = makeIndexOfs(notNullish);
+export const positiveIdxs = makeIndexOfs(isPositive);
 
 export function getMinMax(data, _i0, _i1, sorted = 0, log = false) {
 //	console.log("getMinMax()");
 
-	let getEdgeIdx = log ? positiveIdx : nonNullIdx;
+	let getEdgeIdxs = log ? positiveIdxs : nonNullIdxs;
 	let predicate = log ? isPositive : notNullish;
 
-	// needed?
-	_i0 = getEdgeIdx(data, _i0, _i1,  1);
-	_i1 = getEdgeIdx(data, _i0, _i1, -1);
+	[_i0, _i1] = getEdgeIdxs(data, _i0, _i1);
 
 	let _min = data[_i0];
 	let _max = data[_i0];


### PR DESCRIPTION
That's not a typo in the title; this PR makes a single, 10 million point series render in 100ms instead of 300ms (on a 15W laptop CPU from 2021)

![blinky](https://github.com/user-attachments/assets/493450a9-f0a2-4391-961c-3d78596eca68)

But how did the fastest JS plotting lib leave so much performance on the table?

Well, datasets this large are rare. Once you ask for this much data, both the query latency and download time will likely make you rethink your life choices long before you notice a 200ms difference in rendering time. More typical queries [that return fewer than 50k points] already rendered in < 10ms, so there wasn't much reason to deep dive into the profiler - everything was fine.

So, why now?

I'm getting started on uPlot 1.7 - a stepping stone to 2.0 - and since this will likely be the last 1.x bump, I wanted to either ship or discard some ideas I've had over the years. One of these was to switch the all-important linear path-builder from its modified [M4 decimation](https://www.vldb.org/pvldb/vol7/p797-jugel.pdf) to [LTTB decimation](https://github.com/sveinn-steinarsson/flot-downsample/blob/master/jquery.flot.downsample.js), or adapt [Simplify.js](https://mourner.github.io/simplify-js/) to improve drawing performance; [ctx.lineTo()](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineTo) tends to be the bottleneck for large datasets, so doing less of it without impacting the result would be great.

An [LTTB branch](https://github.com/leeoniya/uPlot/tree/lttb-test) showed some promise in the past, but issues like https://github.com/timescale/timescaledb-toolkit/issues/501 make me wonder if the nature of the algorithm (to bucket by pre-defined steps) could miss spikes at the bucket boundaries with certain data shape + threshold combos. ~~Perhaps these concerns are unfounded~~ [1], but not knowing if there are some easy-to-miss regressions would haunt me. uPlot's current approach is battle-tested for multiple years with millions of users, and the ROI is not big enough to offset the risk, IMHO.

This week, I went ahead and adapted Simplify.js to uPlot's columnar data layout and its linear pathbuilder in a [simplify-js branch](https://github.com/leeoniya/uPlot/tree/simplify-js), but the resulting output was underwhelming:

before:
![Screenshot_20241225_200031](https://github.com/user-attachments/assets/ba4a91fe-efaf-43a3-a79a-8b38632ae26a)

after:
![Screenshot_20241225_195836](https://github.com/user-attachments/assets/7c4eaa70-94ac-47e6-b1ad-16e6f75c7f15)

Nevertheless, the process of trying out path simplification did lead me to stress test an artificial 10M point dataset against the current M4 approach. I quickly noticed that Chrome's profiler failed to properly attribute the cost of some known-hot functions, while surfacing obviously-inexpensive others. After wrestling the profiler into submission (a rant for another day), it highlighted some valid points of concern. The M4 decimation, as implemented, worked exclusively in the pixel domain, which meant running all 10M raw x and y values through the `u.valToPos()` scaling functions, lighting up like a Christmas tree. To make matters worse, the scaling functions did some things at runtime that could have been done once at init time.

So in this PR...

- Decimation is disabled for fewer datapoints than 4x the plot pixel width, since there's no benefit from the added complexity, and this negatively impacts high frequency data updates such as streaming a few thousand points
- Decimation is now done almost entirely in the raw value domain (both x and y) rather than pixel domain, bypassing the scaling functions 99.99% of the time
- All scaling functions are pre-initialized with known constants at init time, reducing the hot path to simple, branchless math
- Functions for finding data min/max have been slightly optimized and combined

[1] the [paper](https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf) definitely discusses issues that can arise from this algorithm, since it works best on regularly-spaced data, and since only one data-point is chosen per bucket, there is no bucket threshold that can catch both a downward and upward spike in the same bucket.