### PR TITLE
fix series toggle when `cursor.points.show()` may have returned `undefined`

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -2418,7 +2418,7 @@ export default function uPlot(opts, data, then) {
 
 			if (showCursor) {
 				let pt = cursorOnePt ? cursorPts[0] : cursorPts[i];
-				elTrans(pt, -10, -10, plotWidCss, plotHgtCss);
+				pt && elTrans(pt, -10, -10, plotWidCss, plotHgtCss);
 			}
 		}
 	}


### PR DESCRIPTION
After update from 1.6.27 to 1.6.31 faced with a problem of toggling series at the chart.
I give serie option show field the value of false or some function usually, and now error happens at 
<img width="522" alt="Screenshot 2025-02-25 at 16 17 25" src="https://github.com/user-attachments/assets/4598c522-8280-46e2-90db-84938b46ddf7" />
because el is undefined, to prevent this error would be good to check if pt is not undefined or null. Have done it at the scene, but can move directly to elTrans function. 

But it's better to search the root cause, but I gave up on fnOrSelf moment, so asking for a help or accepting this change.