### PR TITLE
Fixed type error for MouseListener

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -434,7 +434,7 @@ declare namespace uPlot {
 	export namespace Cursor {
 		export type LeftTop              = [left: number, top: number];
 
-		export type MouseListener        = (e: MouseEvent) => null;
+		export type MouseListener        = (e: MouseEvent) => void;
 
 		export type MouseListenerFactory = (self: uPlot, targ: HTMLElement, handler: MouseListener) => MouseListener | null;
 


### PR DESCRIPTION
I got the following error in my project:

```

TS2322: Type '(u: uPlot, targ: HTMLElement, handler: MouseListener) => (e: MouseEvent) => void' is not assignable to type 'MouseListenerFactory'.
  Call signature return types '(e: MouseEvent) => void' and 'MouseListener' are incompatible.
    Type 'void' is not assignable to type 'null'.

    src/app/component.ts:303:10:
      303 │           click: (u, targ, handler) => {
          ╵           ~~~~~

  The expected type comes from property 'click' which is declared here on type 'Bind'

    node_modules/uplot/dist/uPlot.d.ts:439:3:
      439 │       click?:       MouseListenerFactory;
          ╵       ~~~~~

```

As the return type is void for the callback, types should accept a void.