### PR TITLE
use implicit locale for Intl.NumberFormat

### DIFF
--- a/dist/uPlot.cjs.js
+++ b/dist/uPlot.cjs.js
@@ -441,12 +441,7 @@ function _rangeNum(_min, _max, cfg) {
 }
 
 // alternative: https://stackoverflow.com/a/2254896
-let numFormatter;
-try {
-    numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
-} catch (e) {
-    numFormatter = new Intl.NumberFormat('en-US');
-}
+const numFormatter = new Intl.NumberFormat();
 const fmtNum = val => numFormatter.format(val);
 
 const M = Math;

--- a/dist/uPlot.cjs.js
+++ b/dist/uPlot.cjs.js
@@ -441,7 +441,12 @@ function _rangeNum(_min, _max, cfg) {
 }
 
 // alternative: https://stackoverflow.com/a/2254896
-const numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
+let numFormatter;
+try {
+    numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
+} catch (e) {
+    numFormatter = new Intl.NumberFormat('en-US');
+}
 const fmtNum = val => numFormatter.format(val);
 
 const M = Math;

--- a/dist/uPlot.esm.js
+++ b/dist/uPlot.esm.js
@@ -439,12 +439,7 @@ function _rangeNum(_min, _max, cfg) {
 }
 
 // alternative: https://stackoverflow.com/a/2254896
-let numFormatter;
-try {
-    numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
-} catch (e) {
-    numFormatter = new Intl.NumberFormat('en-US');
-}
+const numFormatter = new Intl.NumberFormat();
 const fmtNum = val => numFormatter.format(val);
 
 const M = Math;

--- a/dist/uPlot.esm.js
+++ b/dist/uPlot.esm.js
@@ -439,7 +439,12 @@ function _rangeNum(_min, _max, cfg) {
 }
 
 // alternative: https://stackoverflow.com/a/2254896
-const numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
+let numFormatter;
+try {
+    numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
+} catch (e) {
+    numFormatter = new Intl.NumberFormat('en-US');
+}
 const fmtNum = val => numFormatter.format(val);
 
 const M = Math;

--- a/src/utils.js
+++ b/src/utils.js
@@ -267,7 +267,12 @@ function _rangeNum(_min, _max, cfg) {
 }
 
 // alternative: https://stackoverflow.com/a/2254896
-const numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
+let numFormatter;
+try {
+    numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
+} catch (e) {
+    numFormatter = new Intl.NumberFormat('en-US');
+}
 export const fmtNum = val => numFormatter.format(val);
 
 const M = Math;

--- a/src/utils.js
+++ b/src/utils.js
@@ -267,12 +267,7 @@ function _rangeNum(_min, _max, cfg) {
 }
 
 // alternative: https://stackoverflow.com/a/2254896
-let numFormatter;
-try {
-    numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
-} catch (e) {
-    numFormatter = new Intl.NumberFormat('en-US');
-}
+const numFormatter = new Intl.NumberFormat();
 export const fmtNum = val => numFormatter.format(val);
 
 const M = Math;


### PR DESCRIPTION
I have users who have navigator.language = `en-US@posix` which causes uplot to fail. 

The reason why this is occurring is because the locale for some Linux systems include @posix at the end. So rather than en-US, it is en-US@posix. For more info see https://wiki.archlinux.org/title/Locale

uPlot uses navigator.language to detect the current locale, which can be invalid. Affected code here: https://github.com/leeoniya/uPlot/blob/master/dist/uPlot.esm.js#L442 

`
uPlot.cjs.js:436 Uncaught RangeError: Incorrect locale information provided
at new NumberFormat (<anonymous>)
at ../../node_modules/uplot/dist/uPlot.cjs.js (uPlot.cjs.js:436:22)
at __require2 (chunk-TSYC6FF4.js:53:50)
at webpackUniversalModuleDefinition (universalModuleDefinition:4:1)
at ../../node_modules/uplot-react/uplot-react.js (universalModuleDefinition:11:1)
at __require2 (chunk-TSYC6FF4.js:53:50)
at ../../node_modules/@splunk/visualizations/Timeline.js (esm-externals:uplot-react:3:1)
at __require2 (chunk-TSYC6FF4.js:53:50)
at ../../node_modules/@splunk/dashboard-presets/CloudPreset.js (Timeline:3:15)
at __require2 (chunk-TSYC6FF4.js:53:50)
`


I would like to submit a PR which adds a try catch block to **line 270** of `src/utils.js` and respectively the same line in `uplot.esm.js` and `uplot.cjs.js`

**Change this line:** 

`const numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');`

**To:**

`let numFormatter;
try {
    numFormatter = new Intl.NumberFormat(domEnv ? nav.language : 'en-US');
} catch (e) {
    numFormatter = new Intl.NumberFormat('en-US');
}`



Fixes: https://github.com/leeoniya/uPlot/issues/1053#issue-2993675078