### PR TITLE
Improve layout and styling of the demos page

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -25,6 +25,7 @@
 
 		h1 {
 			font-size: 24px;
+			text-align: center;
 		}
 
 		h2 {
@@ -35,11 +36,29 @@
 			display: block;
 			padding: 4px;
 		}
+
+		section {
+        	display: flex;
+        	flex-direction: column;
+        	justify-content: center;
+        	border-radius: 0.25rem;
+        	padding: 1rem;
+        	background-color: #fafafa;
+      	}
+
+		.container {
+        	max-width: 640px;
+        	margin: 0 auto;
+        	padding: 1rem;
+      	}
 	</style>
 </head>
 <body>
+	<main class="container">
 	<h1>μPlot Demos</h1>
 
+	<h2>Variety</h2>
+	<section>
 	<a href="../bench/uPlot.html">Multi time-series (two scales)</a>
 	<a href="area-fill.html">Areas chart</a>
 	<a href="grid-over-series.html">Grid over series</a>
@@ -84,12 +103,13 @@
 	<a href="timeseries-discrete.html">Discrete &amp; shifted series w/sync</a>
 	<a href="update-cursor-select-resize.html">Maintains location of cursor/select/hoverPts during resize (test)</a>
 	<a href="axis-indicators.html">Plugin to render hovered values on axes</a>
-
 	<a href="months-ru.html">Russian month names on date/time axis</a>
 	<a href="add-del-series.html">Dynamically add or delete series</a>
 	<a href="scroll-sync.html">Sync chart position when inside a scrollable container</a>
+	</section>
 
 	<h2>Drawing</h2>
+	<section>
 	<a href="trendlines.html">Trendlines from zoomed range &amp; zoom snapping</a>
 	<a href="candlestick-ohlc.html">OHLC plugin + legend-as-tooltip plugin</a>
 	<a href="box-whisker.html">Box &amp; whisker plugin + legend-as-tooltip plugin</a>
@@ -102,8 +122,10 @@
 	<a href="measure-datums.html">Measurement datums via keyboard</a>
 	<a href="wind-direction.html">Wind direction renderer</a>
 	<a href="svg-image.html">Render to image/png</a>
+	</section>
 
 	<h2>Zooming</h2>
+	<section>
 	<a href="zoom-variations.html">Different zoom variants (adaptive, uni/omnidirectional)</a>
 	<a href="zoom-fetch.html">Fetch &amp; update data on zoom</a>
 	<a href="zoom-ranger.html">Secondary sync'd overview chart for x-axis zoom ranging</a>
@@ -111,8 +133,12 @@
 	<a href="zoom-ranger-xy.html">Secondary sync'd overview chart for x/y-axis zoom ranging</a>
 	<a href="zoom-touch.html">Pinch zooming/panning plugin</a>
 	<a href="zoom-wheel.html">Mouswheel zooming plugin</a>
+	</section>
 
 	<h2>Junk</h2>
+	<section>
 	<a href="stacked-series.html">Stacked series</a>
+	</section>
+	</main>
 </body>
 </html>


### PR DESCRIPTION
## Description

Hello leeoniya!

This PR introduces a change to improve the readability and overall user experience of the main demos page.

## Motivation

Currently, the list of demos is aligned to the far left of the page. On wider screens, this can make it less comfortable to view, as the user's focus is pulled to one side.

By centering the main content block, the page feels more balanced and is ergonomically easier to read.

## Changes

To achieve this, I have made the following changes.

1. Wrapped the page content in a `<main class="container">` element.
2. Applied CSS to the `.container` to set a `max-width` and center it on the page using `margin: 0 auto`. This makes the layout responsive and readable on all screen sizes.
3. Added simple styling to these sections (`background-color`, `padding`, `border-radius`) to visually separate the categories and make the page more organized.
4. Centered the main `<h1>` title to match the new centered layout.
5. Additionally, I've named the first section heading to `Variety`. I felt this word better captures the diverse nature of the demos in that group. I'm open to feedback on this as well.

## Result

Here is a quick look at the visual change.

|Before|After|
|:--:|:--:|
|<img width="1919" height="905" alt="image" src="https://github.com/user-attachments/assets/65e14297-8c7d-4b81-9631-1dcdad3312a4" />|<img width="1919" height="904" alt="image" src="https://github.com/user-attachments/assets/c9fd30bd-730d-4794-8d1a-a79451044408" />|

I believe this makes the page look cleaner and more modern. Of course, I'm completely open to feedback on the styling. If this approach doesn't align with the project's vision (ex. no-css, no-style), please feel free to close this PR.

Thank you for your time and for creating such a great library!