### PR TITLE
fix(types): Allow setScale to accept { min: null, max: null }

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -77,7 +77,7 @@ declare class uPlot {
 	setData(data: uPlot.AlignedData, resetScales?: boolean): void;
 
 	/** sets the limits of a scale & redraws (used for zooming) */
-	setScale(scaleKey: string, limits: { min: number | null; max: number | null }): void;
+	setScale(scaleKey: string, limits: ({ min: number; max: number } | { min: null; max: null })): void;
 
 	/** sets the cursor position (relative to plotting area) */
 	setCursor(opts: {left: number, top: number}, fireHook?: boolean): void;


### PR DESCRIPTION
Hi! 
First of all, let me thank you for this amazing library!

This PR introduces a minor change in the `setScale` type definition, allowing it to be called with `{min: null, max: null}`, as documented in #924.

The new type only allows null values if both arguments are null. Otherwise, I have seen that the axis may disappear in some edge case (such as `{min: 0, max: null}`).

If you find it reasonable, I can add some checks at the beggining of the `setScale` function to prevent this. The presence of special "numbers" such as `NaN` or `Infinity` also cause the same problem. However, I understand if you prefer to leave validation to the user to avoid additional runtime checks.