### PR TITLE
fix(types): setSeries hook should have 'focus' property

### DIFF
--- a/dist/uPlot.d.ts
+++ b/dist/uPlot.d.ts
@@ -1170,7 +1170,7 @@ declare namespace uPlot {
 			setSelect?:  (self: uPlot) => void;
 
 			/** fires after a series is toggled or focused */
-			setSeries?:  (self: uPlot, seriesIdx: number | null, opts: Series) => void;
+			setSeries?:  (self: uPlot, seriesIdx: number | null, opts: {show?: boolean, focus?: boolean}) => void;
 
 			/** fires after data is updated updated */
 			setData?:    (self: uPlot) => void;


### PR DESCRIPTION
Hi,
I think the `setSeries` hook `opts` can only contain `show` or `focus`. At the moment, accessing `focus` on a TS environment throws an error: `Property 'focus' does not exist on type 'Series'.`

Regards! 