### PR TITLE
update numAxisSplits to throw error instead of infinite loop

### DIFF
--- a/src/opts.js
+++ b/src/opts.js
@@ -599,6 +599,12 @@ export function numAxisSplits(self, axisIdx, scaleMin, scaleMax, foundIncr, foun
 
 	scaleMin = forceMin ? scaleMin : roundDec(incrRoundUp(scaleMin, foundIncr), numDec);
 
+	if (scaleMin === scaleMax)
+		throw new RangeError("scaleMin cannot be equal to scaleMax");
+
+	if (roundDec(scaleMin + foundIncr, numDec) === scaleMin)
+		throw new RangeError("foundIncr too small for scaleMin");
+
 	for (let val = scaleMin; val <= scaleMax; val = roundDec(val + foundIncr, numDec))
 		splits.push(Object.is(val, -0) ? 0 : val);		// coalesces -0
 


### PR DESCRIPTION
We have had some instances recently where the min and max being equal crashes the browser in Grafana:

- https://github.com/grafana/grafana/pull/115030
- https://github.com/grafana/grafana/pull/109702

While we should not attempt to remediate this inside uPlot, it would be better to just throw if we can tell that's about to happen rather than running out of memory.