### PR TITLE
perf(legend): reduce amount stress caused by too many legends

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -49,14 +49,17 @@ export function setStylePx(el, name, value) {
 	el.style[name] = value + "px";
 }
 
-export function placeTag(tag, cls, targ, refEl) {
+export function placeTag(tag, cls, targ, refEl, frag) {
 	let el = doc.createElement(tag);
 
 	if (cls != null)
 		addClass(el, cls);
 
-	if (targ != null)
+	if (frag != null) {
+		frag.appendChild(el);
+	} else if (targ != null) {
 		targ.insertBefore(el, refEl);
+	}
 
 	return el;
 }

--- a/src/uPlot.css
+++ b/src/uPlot.css
@@ -1,7 +1,5 @@
 .uplot,
-.uplot *,
-.uplot *::before,
-.uplot *::after {
+.uplot * {
 	box-sizing: border-box;
 }
 
@@ -79,6 +77,7 @@
 .u-inline.u-live th::after {
 	content: ":";
 	vertical-align: middle;
+	box-sizing: border-box;
 }
 
 .u-inline:not(.u-live) .u-value {

--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -589,6 +589,8 @@ export default function uPlot(opts, data, then) {
 			NULL_LEGEND_VALUES[k] = LEGEND_DISP;
 	}
 
+	let legendRowsFrag = null;
+
 	if (showLegend) {
 		legendTable = placeTag("table", LEGEND, root);
 		legendBody = placeTag("tbody", null, legendTable);
@@ -600,15 +602,20 @@ export default function uPlot(opts, data, then) {
 			legendHead = placeTag("thead", null, legendTable, legendBody);
 
 			let head = placeTag("tr", null, legendHead);
-			placeTag("th", null, head);
+			let headFrag = doc.createDocumentFragment();
+			placeTag("th", null, null, null, headFrag);
 
 			for (var key in legendCols)
-				placeTag("th", LEGEND_LABEL, head).textContent = key;
+				placeTag("th", LEGEND_LABEL, null, null, headFrag).textContent = key;
+
+			head.appendChild(headFrag);
 		}
 		else {
 			addClass(legendTable, LEGEND_INLINE);
 			legend.live && addClass(legendTable, LEGEND_LIVE);
 		}
+
+		legendRowsFrag = doc.createDocumentFragment();
 	}
 
 	const son  = {show: true};
@@ -620,7 +627,8 @@ export default function uPlot(opts, data, then) {
 
 		let cells = [];
 
-		let row = placeTag("tr", LEGEND_SERIES, legendBody, legendBody.childNodes[i]);
+		const rowFrag = doc.createDocumentFragment();
+		let row = placeTag("tr", LEGEND_SERIES, rowFrag, null);
 
 		addClass(row, s.class);
 
@@ -690,6 +698,8 @@ export default function uPlot(opts, data, then) {
 			v.textContent = "--";
 			cells.push(v);
 		}
+
+		legendRowsFrag.appendChild(rowFrag);
 
 		return [row, cells];
 	}
@@ -1008,7 +1018,6 @@ export default function uPlot(opts, data, then) {
 			addClass(pt, CURSOR_PT);
 			addClass(pt, s.class);
 			elTrans(pt, -10, -10, plotWidCss, plotHgtCss);
-			over.insertBefore(pt, cursorPts[si]);
 
 			return pt;
 		}
@@ -3484,6 +3493,27 @@ export default function uPlot(opts, data, then) {
 	series.forEach(initSeries);
 
 	axes.forEach(initAxis);
+
+	requestAnimationFrame(() => {
+		if (cursor.show && cursorPts.length > 0) {
+			let cursorFrag = doc.createDocumentFragment();
+			for (let i = 0; i < cursorPts.length; i++) {
+				if (cursorPts[i] != null) {
+					cursorFrag.appendChild(cursorPts[i]);
+				}
+			}
+			if (cursorFrag.hasChildNodes()) {
+				let refEl = over.firstChild;
+				over.insertBefore(cursorFrag, refEl);
+			}
+		}
+
+		requestAnimationFrame(() => {
+			if (showLegend && legendRowsFrag != null && legendRowsFrag.hasChildNodes()) {
+				legendBody.appendChild(legendRowsFrag);
+			}
+		});
+	});
 
 	if (then) {
 		if (then instanceof HTMLElement) {


### PR DESCRIPTION
This PR will contain these main changes:
- using document fragment to avoid create elements directly in the dom
- using requestFrameAnimation + insert the legends & cursor points last
- remove ::after and ::before css to avoid costs of reflow

To test:

```diff
diff --git a/bench/uPlot-10M.html b/bench/uPlot-10M.html
index 5af53e2..ca855a6 100644
--- a/bench/uPlot-10M.html
+++ b/bench/uPlot-10M.html
@@ -109,7 +109,7 @@
 			let data1 = prepData(2e6);
 			let u1 = makeChart(data1, false);
 
-			let data2 = prepData(40_000, 50, 2);
+			let data2 = prepData(100, 10000, 2);
 			let u2 = makeChart(data2, true);
 
 			setTimeout(() => {
@@ -131,4 +131,4 @@
 			}, 2000);
 		</script>
 	</body>
-</html>
\ No newline at end of file
+</html>
```

Before:

<img width="961" height="794" alt="image" src="https://github.com/user-attachments/assets/7cd19e82-390c-4bd3-9007-addb36f70f65" />

After:

<img width="950" height="796" alt="image" src="https://github.com/user-attachments/assets/8222472c-9f65-42e4-bff5-40cb00f45083" />

> Maybe in the future introduce a feature to virtualize or just render top 20 legends and add button to load more.

I found this while trying to optimize the https://github.com/SigNoz/signoz/issues/9784

> This is breaking change since it could break people that expected legends to be on DOM after new uPlot.