### PR TITLE
update lightweight-charts bench demo for v5 of the library

### DIFF
--- a/bench/lightweight-charts.html
+++ b/bench/lightweight-charts.html
@@ -48,34 +48,34 @@
 
 				const chart = LightweightCharts.createChart(document.body, {
 					width: 1920,
-					height: 600
-				});
-
-				chart.timeScale().setVisibleRange({
-					from: data[0][0].time,
-					to: data[0][data[0].length - 1].time,
+					height: 600,
+					timeScale: {
+						minBarSpacing: 0.0001, // Unrestrict the minimum zoom level
+					},
 				});
 
 				// CPU
-				const cpu = chart.addLineSeries({
+				const cpu = chart.addSeries(LightweightCharts.LineSeries, {
 					lineWidth: 1,
 					color: 'red',
 				});
 				cpu.setData(data[0]);
 
 				// RAM
-				const ram = chart.addLineSeries({
+				const ram = chart.addSeries(LightweightCharts.LineSeries, {
 					lineWidth: 1,
 					color: 'blue',
 				});
 				ram.setData(data[1]);
 
 				// TCP Out
-				const tcp = chart.addLineSeries({
+				const tcp = chart.addSeries(LightweightCharts.LineSeries, {
 					lineWidth: 1,
 					color: 'green',
 				});
 				tcp.setData(data[2]);
+
+				chart.timeScale().fitContent();
 
 				wait.textContent = "Done!";
 				console.timeEnd('chart');


### PR DESCRIPTION
Hi, I came across this benchmark file for Lightweight Charts and noticed that it loads the latest version of the library but hasn't had the syntax updated for the v5 breaking changes. I've made minimal changes to get it working again, and also added the `minBarSpacing` setting so that all the datapoints are plotted within the visual viewport of the chart (as this appears to match what the other examples are doing).