### PR TITLE
Fix: When findGaps, do not use spread operator because it may cause Maximum call stack size exceeded

### DIFF
--- a/src/paths/linear.js
+++ b/src/paths/linear.js
@@ -146,9 +146,9 @@ export function linear(opts) {
 
 			if (!series.spanGaps) { // skip in mode: 2?
 			//	console.time('gaps');
-				let gaps = [];
-
-				hasGap && gaps.push(...findGaps(dataX, dataY, idx0, idx1, dir, pixelForX, alignGaps));
+				let gaps = hasGap
+					? findGaps(dataX, dataY, idx0, idx1, dir, pixelForX, alignGaps)
+					: [];
 
 			//	console.timeEnd('gaps');
 

--- a/src/paths/spline.js
+++ b/src/paths/spline.js
@@ -63,9 +63,7 @@ export function splineInterp(interp, opts) {
 
 			if (!series.spanGaps) {
 			//	console.time('gaps');
-				let gaps = [];
-
-				gaps.push(...findGaps(dataX, dataY, idx0, idx1, dir, pixelForX, alignGaps));
+				let gaps = findGaps(dataX, dataY, idx0, idx1, dir, pixelForX, alignGaps)
 
 			//	console.timeEnd('gaps');
 

--- a/src/paths/stepped.js
+++ b/src/paths/stepped.js
@@ -84,9 +84,7 @@ export function stepped(opts) {
 
 			if (!series.spanGaps) {
 			//	console.time('gaps');
-				let gaps = [];
-
-				gaps.push(...findGaps(dataX, dataY, idx0, idx1, dir, pixelForX, alignGaps));
+				let gaps = findGaps(dataX, dataY, idx0, idx1, dir, pixelForX, alignGaps)
 
 			//	console.timeEnd('gaps');
 


### PR DESCRIPTION
When setting large, interleaved datasets (~1M points), findGaps will crash due to the spread operator.

The proposed solution is to assign directly from findGaps.
It appears to be a simple fix and I could not think of any edge case that I overlooked.
I applied it to linear, stepped and spline, but only tested it for linear.

Since uPlot is capable of handling large number of gaps apart from this issue, I though this might be a valuable change.