### PR TITLE
Let user pick the stroke order

### DIFF
--- a/src/uPlot.js
+++ b/src/uPlot.js
@@ -1620,7 +1620,10 @@ export default function uPlot(opts, data, then) {
 				}
 			});
 
-			series.forEach((s, i) => {
+			// order the strokes by self._zOrder (a permutation of series indices) when set, so callers can lift series on top without reordering the series/data arrays.
+			// the order only affects stroking — all paths (incl. band fills) are built above, order-independently.
+			for (let i of self._zOrder || series.keys()) {
+				let s = series[i];
 				if (i > 0 && s.show) {
 					let _ctxAlpha = ctxAlpha;
 
@@ -1646,7 +1649,7 @@ export default function uPlot(opts, data, then) {
 
 					fire("drawSeries", i);
 				}
-			});
+			}
 
 			if (shouldAlpha)
 				ctx.globalAlpha = ctxAlpha = 1;


### PR DESCRIPTION
When my mouse hovers over a series, I'd like to bring it up above the other series. This patch lets the user choose the stroke order.

This is wandb: the hovered line is brought to the top and the other runs are translucent.

<img width="254" height="271" alt="Screenshot 2026-07-01 at 2 35 04 PM" src="https://github.com/user-attachments/assets/499d920f-d930-4b43-8747-2ee248ad2c40" />

Here's my own chart: I increase the width of the line and make the other runs translucent, but there are enough runs to obscure the hovered line anyway.

<img width="415" height="77" alt="Image" src="https://github.com/user-attachments/assets/5c1158c4-0110-4427-8ef6-d25745aae619" />

After this patch, the cerulean line is now visible:

<img width="203" height="209" alt="Screenshot 2026-07-01 at 2 42 32 PM" src="https://github.com/user-attachments/assets/2248e1e2-f89d-433a-bee4-18c5c51790e0" />

The hovered line swaps at 60 fps as my mouse sweeps over the graph, so this method avoids reordering the data (which would be expensive).

If `self._zOrder` isn't the API you want (I know no javascript), other solutions would be fine too.