### PR TITLE
Add ink-uplot to Third-party Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Additionally, an ever-expanding collection of runnable [/demos](https://leeoniya
 
 - [React, Vue.js and Svelte](https://github.com/skalinichev/uplot-wrappers) (Sergey Kalinichev)
 - [Python](https://github.com/stephane-caron/uplot-python) (Stéphane Caron)
+- [Terminal (React Ink)](https://github.com/planadecu/ink-uplot) (Jordi Planadecursach)
 
 ---
 ### Performance


### PR DESCRIPTION
Adds [ink-uplot](https://github.com/planadecu/ink-uplot) under Third-party Integrations.

It's a terminal renderer for uPlot: it reuses standard browser uPlot config (`opts`/`data`, series, scales, dual axes, custom tick formatters) and draws the chart in the terminal via React Ink — as truecolor Unicode block art, or as real inline images through the kitty, sixel, and iTerm2 graphics protocols. Useful for CLI dashboards, time series, and live/streaming plots.

A terminal integration alongside the existing framework and Python wrappers.